### PR TITLE
Odd num support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # swiss-tournament
-Swiss style tournament api built with FastAPI. At the moment no tie breakers. Must have an even number of competitors.
+Swiss style tournament api built with FastAPI. If there are an odd number of competitors then one
+match per round will have a bye. Tie-breaker involves a new tournament for those players
+to compete again.
 
 ### Setup
 

--- a/routers/matches.py
+++ b/routers/matches.py
@@ -26,7 +26,7 @@ def get_matches(
     return crud.get_matches(db=db, tournament_id=tournament_id, round=round)
 
 
-@router.get('/matches/match_competitors', response_model=List[schemas.Match], status_code=status.HTTP_201_CREATED)
+@router.get('/matches/match_competitors', response_model=List[schemas.Match])
 def match_competitors(
     tournament_id: int,
     db: Session = Depends(get_db),
@@ -38,9 +38,6 @@ def match_competitors(
         raise HTTPException(status_code=404, detail='Not found.')
 
     competitors = crud.get_tournament_competitors(db=db, tournament_id=tournament_id)
-
-    if len(competitors) % 2 != 0:
-        raise HTTPException(status_code=404, detail='Must have an even number of competitors to begin.')
 
     round = crud.get_current_round(db=db, tournament_id=tournament_id)
     matches = crud.get_matches(db=db, tournament_id=tournament_id, round=round)

--- a/schemas.py
+++ b/schemas.py
@@ -25,7 +25,7 @@ class Tournament(TournamentBase):
 class MatchBase(BaseModel):
     tournament_id: int
     competitor_one: int
-    competitor_two: int
+    competitor_two: Optional[int]
     round: int
     winner_id: Optional[int]
     loser_id: Optional[int]
@@ -34,7 +34,7 @@ class MatchBase(BaseModel):
 class MatchCreate(MatchBase):
     tournament_id: int
     competitor_one: int
-    competitor_two: int
+    competitor_two: Optional[int]
     round: int
     winner_id: Optional[int]
     loser_id: Optional[int]
@@ -51,7 +51,7 @@ class Match(MatchBase):
     id: int
     tournament_id: int
     competitor_one: int
-    competitor_two: int
+    competitor_two: Optional[int]
     winner_id: Optional[int]
     loser_id: Optional[int]
 


### PR DESCRIPTION
Tournaments can have an odd number of competitors. This allows for tie breakers to be handled by another tournament as well as a sort of semi-final (or however many are required to get a single winner). 